### PR TITLE
commit for issue #14 : Check /post/xyz/edit/KEY cannot be getted or posted without correct key

### DIFF
--- a/Blog/static/Blog/style.css
+++ b/Blog/static/Blog/style.css
@@ -1,0 +1,9 @@
+.href-div{
+          padding-top: 30px;
+}
+.alert{
+      left: 40px;
+}
+.navbar-brand{
+      padding-left: 484px;
+}

--- a/Blog/tests.py
+++ b/Blog/tests.py
@@ -70,8 +70,8 @@ class EditLinkTest(TestCase):
     def test_changes_edits_the_post_successfully(self):
         update_data = {'title': 'test title to check the updation', 'content': 'test content to check the updation is working'}
         response = self.client.post(reverse('Blog:homepage', kwargs={'id': self.instance.id, 'secret_key': self.instance.secret_key}), update_data, follow=True)
-        updated_data = Blog.objects.get(title='test title to check the updation')
-        self.assertEquals(update_data['content'], 'test content to check the updation is working' )
+        fetch_updated_data = Blog.objects.get(title='test title to check the updation')
+        self.assertEquals(fetch_updated_data.content, 'test content to check the updation is working' )
 
 
 

--- a/Blog/tests.py
+++ b/Blog/tests.py
@@ -70,7 +70,8 @@ class EditLinkTest(TestCase):
     def test_changes_edits_the_post_successfully(self):
         update_data = {'title': 'test title to check the updation', 'content': 'test content to check the updation is working'}
         response = self.client.post(reverse('Blog:homepage', kwargs={'id': self.instance.id, 'secret_key': self.instance.secret_key}), update_data, follow=True)
-        self.assertContains(response, 'Your post has been successfully Updated!!!', status_code=200)
+        updated_data = Blog.objects.get(title='test title to check the updation')
+        self.assertEquals(update_data['content'], 'test content to check the updation is working' )
 
 
 


### PR DESCRIPTION
-Created a post with Django orm
-Checked /post/xyz/edit/KEY cannot be getted or posted without correct key
    - Wrong key returns a 404 response
    - Verified that  posting new content and title edits the post successfully.
